### PR TITLE
Implement and Switch badges for mission joining and leaving - Actions

### DIFF
--- a/src/component/Mission/Missions.js
+++ b/src/component/Mission/Missions.js
@@ -30,15 +30,15 @@ const Missions = () => {
                 <td className={style.cell}>{m.mission_name}</td>
                 <td className={style.cell}>{m.description}</td>
                 <td className={style.cell}>
-                  {m.reserved ? (
-                    <span className={style.member}>active member</span>
-                  ) : (<span className={style.not_member}>not a member</span>)}
+                  {m.joined ? (
+                    <span className={style.member}>Active Member</span>
+                  ) : (<span className={style.not_member}>NOT A MEMBER</span>)}
                 </td>
                 <td className={style.cell}>
                   <button type="button" className={style.joinMissions} onClick={() => dispatch(joinMission(m.mission_id))}>
-                    {m.reserved ? (
-                      'leave mission'
-                    ) : ('join mission')}
+                    {m.joined ? (
+                      'Leave Mission'
+                    ) : ('Join Mission')}
                   </button>
                 </td>
               </tr>

--- a/src/redux/mission/MissionsSlice.js
+++ b/src/redux/mission/MissionsSlice.js
@@ -21,7 +21,18 @@ export const getAllMissions = createAsyncThunk(GET_MISSIONS, async (_name, thunk
 const missionsSlice = createSlice({
   name: 'allMissions',
   initialState,
-  reducers: { },
+  reducers: {
+    joinMission: (state, action) => {
+      const newMissionsState = state.allMissions.map((mission) => {
+        if (mission.mission_id !== action.payload) {
+          return mission;
+        }
+        return mission.reserved === true ? { ...mission, reserved: false }
+          : { ...mission, reserved: true };
+      });
+      state.allMissions = newMissionsState;
+    },
+  },
   extraReducers: (builder) => {
     builder
       .addCase(getAllMissions.pending, (state) => {

--- a/src/redux/mission/MissionsSlice.js
+++ b/src/redux/mission/MissionsSlice.js
@@ -27,8 +27,8 @@ const missionsSlice = createSlice({
         if (mission.mission_id !== action.payload) {
           return mission;
         }
-        return mission.reserved === true ? { ...mission, reserved: false }
-          : { ...mission, reserved: true };
+        return mission.joined === true ? { ...mission, joined: false }
+          : { ...mission, joined: true };
       });
       state.allMissions = newMissionsState;
     },

--- a/src/redux/mission/MissionsSlice.js
+++ b/src/redux/mission/MissionsSlice.js
@@ -38,7 +38,7 @@ const missionsSlice = createSlice({
           };
           missionArray.push(mission);
         });
-        state.missions = missionArray;
+        state.allMissions = missionArray;
       })
       .addCase(getAllMissions.rejected, (state, action) => {
         state.loading = false;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -8,9 +8,9 @@ const store = configureStore({
   reducer: {
     rockets: rocketReducer,
     dragon: DragonReducer,
-  allMissions: missionsReducer,
+    allMissions: missionsReducer,
   },
-   middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(logger),
+  middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(logger),
 });
 
 export default store;


### PR DESCRIPTION
Hi @MayPyone , @binyamolango 

# Implement mission joining - Actions 

- When a user clicks the "Join Mission" button, action needs to be dispatched to update the store. You need to get the ID of the selected mission and update the state. Remember you mustn't mutate the state. Instead, you need to return a new state object with all missions, but the selected mission will have an extra key `reserved` with its value set to `true`. You could use a JS `filter()` or `map()` to set the value of the new state - i.e.:
```javascript
const newState = state.map(rocket => {
    if(mission.id !== id) 
        return mission;
    return { ...mission, reserved: true };
});

```

- Regardless of which method you choose, make sure you place all your logic in the reducer. In the React view file, you should only dispatch the action with the correct rocket ID as an argument.

#  Implement mission leaving - Actions

- Follow the same logic as with the "Join mission" - but you need to set the `reserved` key to `false`. 
- Dispatch these actions upon click on the corresponding buttons.

# Switch badges for Missions - Conditional components

Missions that the user has joined already should show a badge "Active Member" instead of the default "NOT A MEMBER" and a button "Leave Mission" instead of the "Join Mission" button (as per design).


Use the React conditional rendering syntax:
```javascript
{rocket.reserved && ( 
    // render Cancel Rocket button
)}
```